### PR TITLE
ci: add build and integration tests workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,85 @@
+name: Build & Integration tests
+
+on:
+  workflow_dispatch:
+  push:
+    paths-ignore:
+      - '*.md'
+      - '.github/**'
+    branches:
+      - main
+
+jobs:
+  generate-xcode-project:
+    uses: ./.github/workflows/generate-xcode-project.yml
+
+  build:
+    needs: generate-xcode-project
+    runs-on: macos-15-xlarge
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download xcode project file
+        uses: actions/download-artifact@v4
+        with:
+          name: output-xcodeproj-file
+          path: ./BucketeerOpenFeatureProvider.xcodeproj
+
+      - name: Build
+        env:
+          CI: true
+        run: make build
+
+  build-example:
+    needs: generate-xcode-project
+    runs-on: macos-15-xlarge
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download xcode project file
+        uses: actions/download-artifact@v4
+        with:
+          name: output-xcodeproj-file
+          path: ./BucketeerOpenFeatureProvider.xcodeproj
+
+      - name: Download environment file
+        uses: actions/download-artifact@v4
+        with:
+            name: output-environment-file
+            path: ./environment.xcconfig
+
+      - name: Build example
+        env:
+          CI: true
+        run: make build-example
+
+  test:
+    name: Unit tests
+    needs: generate-xcode-project
+    runs-on: macos-15-xlarge
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download xcode project file
+        uses: actions/download-artifact@v4
+        with:
+          name: output-xcodeproj-file
+          path: ./BucketeerOpenFeatureProvider.xcodeproj
+
+      - name: Download environment file
+        uses: actions/download-artifact@v4
+        with:
+          name: output-environment-file
+          path: ./environment.xcconfig
+
+      - name: Build for testing
+        run: make build-for-testing
+
+      - name: Unit Test
+        run: make test-without-building
+
+  e2e:
+    name: E2E tests
+    needs: generate-xcode-project
+    uses: ./.github/workflows/e2e.yml
+    secrets: inherit


### PR DESCRIPTION
New GitHub Actions workflow:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R1-R85): Added a new workflow to handle the build and integration tests with jobs for generating the Xcode project, building the project, building an example, running unit tests, and executing end-to-end tests.

The CI workflow is green

https://github.com/bucketeer-io/openfeature-swift-client-sdk/actions/runs/13807191723/job/38620393540?pr=4